### PR TITLE
Log used Measurement Devices

### DIFF
--- a/ganymed/src/ganymed/ganymed.py
+++ b/ganymed/src/ganymed/ganymed.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta, timezone
 import socket
 import asyncio
 import traceback
+import psutil as ps
+import ipaddress as ip
 
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS, WritePrecision
@@ -23,6 +25,7 @@ class GanymedServer(ExtensionApp):
     influx_org = Unicode("", config=True, help="InfluxDB Org.")
     influx_bucket = Unicode("ganymed", config=True, help="InfluxDB Bucket.")
     host_name = Unicode(socket.gethostname(), config=True, help="Hostname of the machine.")
+    monitor_net = Unicode("", config=True, help="Network to monitor for active connections.")
 
     def initialize_settings(self):
         """Initialize settings."""
@@ -49,21 +52,28 @@ class GanymedServer(ExtensionApp):
                 self.log.error(traceback.format_exc())
         
 
-    def _report_to_influx(self, currently_active: bool):
+    def _report_to_influx(self, currently_active: bool, used_devices: set[str]):
         """
         Report for the given machine when it was last seen active.
         """
         self.log.info("Reporting: %s is %s", self.host_name, "active" if currently_active else "idle")
         client = InfluxDBClient(url=self.influx_address, token=self.influx_token, org=self.influx_org)
+        write_api = client.write_api(write_options=SYNCHRONOUS)
 
         datum = Point.measurement("kernel_status")\
             .field("presence", 1 if currently_active else 0)\
             .tag("machine", self.host_name)\
             .time(datetime.now(tz=timezone.utc), WritePrecision.NS)
-        
-        write_api = client.write_api(write_options=SYNCHRONOUS)
-
         write_api.write(bucket = self.influx_bucket, record = datum)
+
+        for device in used_devices:
+            datum = Point.measurement("device_usage")\
+                .field("usage", 1)\
+                .tag("machine", self.host_name)\
+                .tag("device", device)\
+                .time(datetime.now(tz=timezone.utc), WritePrecision.NS)
+            write_api.write(bucket = self.influx_bucket, record = datum)
+
         self.log.debug("Report sent.")
     
     async def _periodic_report(self):
@@ -78,8 +88,11 @@ class GanymedServer(ExtensionApp):
             self.log.debug("No kernels found")
             currently_active = False
         
+        self.log.info("Checking for active devices...")
+        used_devices = self._get_used_devices()
+
         try:
-            self._report_to_influx(currently_active)
+            self._report_to_influx(currently_active, used_devices)
         except Exception as e:
             self.log.error(f"Failed to report: {e}")
     
@@ -93,6 +106,28 @@ class GanymedServer(ExtensionApp):
             )
             for session in await sm.list_sessions() if session['type'] == "notebook"
         ]
+    
+    def _get_used_devices(self) -> set[str]:
+        """
+        Returns a set of ip addresses within the configured subnet that are currently connected.
+        This is used as a proxy to see which measurement devices are currently in use by this machine.
+        """
+        if self.monitor_net == "":
+            return set()
+        net = ip.ip_network(self.monitor_net)
+        if net.num_addresses > 8*256:
+            # Too large sub net. This is likely a mistake or abuse.
+            return set()
+        
+        def strip_ip(adr: str, net):
+            return ip.ip_address(int(net.hostmask) & int(ip.ip_address(adr)))
+
+        return set(
+                [
+                    strip_ip(conn.raddr.ip, net) for conn in ps.net_connections(kind='tcp')
+                    if len(conn.raddr) > 0 and ip.ip_address(conn.raddr[0]) in net and conn.status == 'ESTABLISHED'
+                ]
+              )
 
 
 main = launch_new_instance = GanymedServer.launch_instance


### PR DESCRIPTION
When checking for active notebooks, if configured, this will also check for active tcp connections to the configured subnet. In the report, these IPs will be associated with the host computer. This is used as a proxy to see which computer is using which measurement device.

# Data Protection Considerations
This feature has abuse potential, if improperly configured and executed. To prevent this, only a small subnet (at most 2048 IP addresses) and only the bits covered by the hostmask are logged. This should make the data usable for the intended purpose (see above), but make it hard to use for nefarious purposes.

Suppose a `10.1.2.0/24` subnet is configured. This translates to a hostmask of `0.0.0.255`.
So if the IP `10.1.2.123` is connected to a machine with the hostname `amachine`, then the log will state:
```
1970-01-01 00:00 amachine 0.0.0.123
```

This will need discussion.